### PR TITLE
Replace 'raises' with 'throws' in test/.jshintrc globals

### DIFF
--- a/root/test/.jshintrc
+++ b/root/test/.jshintrc
@@ -27,6 +27,6 @@
     "notDeepEqual",
     "strictEqual",
     "notStrictEqual",
-    "raises"
+    "throws"
   ]
 }


### PR DESCRIPTION
'raises' is deprecated. Missed this in my previous QUnit PR, where the API listing was already fixed.
