### PR TITLE
Update the installation git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you haven't already done so, install [grunt-init][].
 Once grunt-init is installed, place this template in your `~/.grunt-init/` directory. It's recommended that you use git to clone this template into that directory, as follows:
 
 ```
-git clone git@github.com:gruntjs/grunt-init-jquery.git ~/.grunt-init/jquery
+git clone https://github.com/gruntjs/grunt-init-jquery.git ~/.grunt-init/jquery
 ```
 
 _(Windows users, see [the documentation][grunt-init] for the correct destination directory path)_


### PR DESCRIPTION
The README has an outdated form of github's clone command that no longer works.
