### PR TITLE
Update .jshintrc to not explicitly set es5: true

### DIFF
--- a/root/.jshintrc
+++ b/root/.jshintrc
@@ -10,6 +10,5 @@
   "unused": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }


### PR DESCRIPTION
Doing so generates an error that prevents the default grunt task from being run. The error seems to be caused by this change recently added to jshint 2.0: https://github.com/jshint/jshint/issues/1137

When `"es5": true` is in the `.jshintrc` file, running `grunt` results in this failure:

```
Running "jshint:gruntfile" (jshint) task
Linting Gruntfile.js ...ERROR
>> ES5 option is now set per default

Warning: Task "jshint:gruntfile" failed. Use --force to continue.

Aborted due to warnings.
```
