### PR TITLE
Use jquery.<name>.js for main source file

### DIFF
--- a/rename.json
+++ b/rename.json
@@ -1,5 +1,5 @@
 {
-  "src/name.js": "src/{%= name %}.js",
+  "src/name.js": "src/jquery.{%= name %}.js",
   "test/name_test.js": "test/{%= name %}_test.js",
   "test/name.html": "test/{%= name %}.html"
 }

--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -21,8 +21,8 @@ module.exports = function(grunt) {
         stripBanners: true
       },
       dist: {
-        src: ['src/<%= pkg.name %>.js'],
-        dest: 'dist/<%= pkg.name %>.js'
+        src: ['src/jquery.<%= pkg.name %>.js'],
+        dest: 'dist/jquery.<%= pkg.name %>.js'
       },
     },
     uglify: {
@@ -31,7 +31,7 @@ module.exports = function(grunt) {
       },
       dist: {
         src: '<%= concat.dist.dest %>',
-        dest: 'dist/<%= pkg.name %>.min.js'
+        dest: 'dist/jquery.<%= pkg.name %>.min.js'
       },
     },
     qunit: {

--- a/root/test/name.html
+++ b/root/test/name.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="../libs/qunit/qunit.css" media="screen">
   <script src="../libs/qunit/qunit.js"></script>
   <!-- Load local lib and tests. -->
-  <script src="../src/{%= name %}.js"></script>
+  <script src="../src/jquery.{%= name %}.js"></script>
   <script src="{%= name %}_test.js"></script>
   <!-- Removing access to jQuery and $. But it'll still be available as _$, if
        you REALLY want to mess around with jQuery in the console. REMEMBER WE


### PR DESCRIPTION
Popular convention is to name source files of jQuery plugins with a "jquery."
prefix.

From the documentation at: http://plugins.jquery.com/docs/names/

> Match your plugin name to your file name,
> e.g., the foo plugin would live in a file named jquery.foo.js.
