### PR TITLE
Prevent NPM publication of the faux package

### DIFF
--- a/template.js
+++ b/template.js
@@ -74,6 +74,7 @@ exports.template = function(grunt, init, done) {
 
     // Generate package.json file, used by npm and grunt.
     init.writePackageJSON('package.json', {
+      private: true,
       name: 'jquery-plugin',
       version: '0.0.0-ignored',
       npm_test: 'grunt qunit',


### PR DESCRIPTION
As a precautionary measure, NPM honors a `private` property in "package.json" files that prevents an `npm publish` command from publishing the package. It would be good to add this to the faux "package.json" file that is created for jQuery plugin development.
