### PR TITLE
Updated JSHint dep version and jshintrc config

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -38,22 +38,16 @@ module.exports = function(grunt) {
       files: ['test/**/*.html']
     },
     jshint: {
+      options: {
+        jshintrc: true
+      },
       gruntfile: {
-        options: {
-          jshintrc: '.jshintrc'
-        },
         src: 'Gruntfile.js'
       },
       src: {
-        options: {
-          jshintrc: 'src/.jshintrc'
-        },
         src: ['src/**/*.js']
       },
       test: {
-        options: {
-          jshintrc: 'test/.jshintrc'
-        },
         src: ['test/**/*.js']
       },
     },

--- a/template.js
+++ b/template.js
@@ -80,7 +80,7 @@ exports.template = function(grunt, init, done) {
       // TODO: pull from grunt's package.json
       node_version: '>= 0.8.0',
       devDependencies: {
-        'grunt-contrib-jshint': '~0.6.0',
+        'grunt-contrib-jshint': '~0.10.0',
         'grunt-contrib-qunit': '~0.2.0',
         'grunt-contrib-concat': '~0.3.0',
         'grunt-contrib-uglify': '~0.2.0',


### PR DESCRIPTION
This updates the minimum `grunt-contrib-jshint` dependency version to be `0.7.1`, in which the ability to set the configuration property `jshintrc` to `true` was added. This setting allows JSHint to find the nearest ".jshintrc" file rather than specifying the exact path in your Gruntfile.

The starter "Gruntfile.js" has also been updated to use that configuration.
